### PR TITLE
Fixing OrderBook and Depth streams and adding possibility to specify update speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 *.fmt
 *.iml
 .env
+.idea

--- a/examples/ws.rs
+++ b/examples/ws.rs
@@ -1,4 +1,4 @@
-use crate::binance::{model::websocket::Subscription, Binance, BinanceWebsocket};
+use crate::binance::{model::websocket::{Subscription, UpdateSpeed}, Binance, BinanceWebsocket};
 use binance_async as binance;
 use failure::Fallible;
 use std::env::var;
@@ -23,9 +23,9 @@ async fn main() -> Fallible<()> {
                 Subscription::Ticker("ethbtc".to_string()),
                 Subscription::AggregateTrade("eosbtc".to_string()),
                 Subscription::Candlestick("ethbtc".to_string(), "1m".to_string()),
-                Subscription::Depth("xrpbtc".to_string()),
+                Subscription::Depth("xrpbtc".to_string(), UpdateSpeed::Default),
                 Subscription::MiniTicker("zrxbtc".to_string()),
-                Subscription::OrderBook("trxbtc".to_string(), 5),
+                Subscription::OrderBook("trxbtc".to_string(), 5, UpdateSpeed::Default),
                 Subscription::Trade("adabtc".to_string()),
                 Subscription::UserData(listen_key),
                 Subscription::MiniTickerAll,

--- a/examples/ws.rs
+++ b/examples/ws.rs
@@ -1,4 +1,7 @@
-use crate::binance::{model::websocket::{Subscription, UpdateSpeed}, Binance, BinanceWebsocket};
+use crate::binance::{
+    model::websocket::{Subscription, UpdateSpeed::Default},
+    Binance, BinanceWebsocket,
+};
 use binance_async as binance;
 use failure::Fallible;
 use std::env::var;
@@ -23,9 +26,9 @@ async fn main() -> Fallible<()> {
                 Subscription::Ticker("ethbtc".to_string()),
                 Subscription::AggregateTrade("eosbtc".to_string()),
                 Subscription::Candlestick("ethbtc".to_string(), "1m".to_string()),
-                Subscription::Depth("xrpbtc".to_string(), UpdateSpeed::Default),
+                Subscription::Depth("xrpbtc".to_string(), Default),
                 Subscription::MiniTicker("zrxbtc".to_string()),
-                Subscription::OrderBook("trxbtc".to_string(), 5, UpdateSpeed::Default),
+                Subscription::OrderBook("trxbtc".to_string(), 5, Default),
                 Subscription::Trade("adabtc".to_string()),
                 Subscription::UserData(listen_key),
                 Subscription::MiniTickerAll,

--- a/src/client/websocket.rs
+++ b/src/client/websocket.rs
@@ -40,10 +40,10 @@ impl BinanceWebsocket {
             Subscription::Candlestick(ref symbol, ref interval) => {
                 format!("{}@kline_{}", symbol, interval)
             }
-            Subscription::Depth(ref symbol) => format!("{}@depth", symbol),
+            Subscription::Depth(ref symbol, ref update_speed) => format!("{}@depth{}", symbol, update_speed),
             Subscription::MiniTicker(ref symbol) => format!("{}@miniTicker", symbol),
             Subscription::MiniTickerAll => "!miniTicker@arr".to_string(),
-            Subscription::OrderBook(ref symbol, depth) => format!("{}@depth{}", symbol, depth),
+            Subscription::OrderBook(ref symbol, depth, ref update_speed) => format!("{}@depth{}{}", symbol, depth, update_speed),
             Subscription::Ticker(ref symbol) => format!("{}@ticker", symbol),
             Subscription::TickerAll => "!ticker@arr".to_string(),
             Subscription::Trade(ref symbol) => format!("{}@trade", symbol),

--- a/src/client/websocket.rs
+++ b/src/client/websocket.rs
@@ -40,10 +40,14 @@ impl BinanceWebsocket {
             Subscription::Candlestick(ref symbol, ref interval) => {
                 format!("{}@kline_{}", symbol, interval)
             }
-            Subscription::Depth(ref symbol, ref update_speed) => format!("{}@depth{}", symbol, update_speed),
+            Subscription::Depth(ref symbol, ref update_speed) => {
+                format!("{}@depth{}", symbol, update_speed)
+            }
             Subscription::MiniTicker(ref symbol) => format!("{}@miniTicker", symbol),
             Subscription::MiniTickerAll => "!miniTicker@arr".to_string(),
-            Subscription::OrderBook(ref symbol, depth, ref update_speed) => format!("{}@depth{}{}", symbol, depth, update_speed),
+            Subscription::OrderBook(ref symbol, depth, ref update_speed) => {
+                format!("{}@depth{}{}", symbol, depth, update_speed)
+            }
             Subscription::Ticker(ref symbol) => format!("{}@ticker", symbol),
             Subscription::TickerAll => "!ticker@arr".to_string(),
             Subscription::Trade(ref symbol) => format!("{}@trade", symbol),

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -85,10 +85,6 @@ pub struct Bids {
     pub price: f64,
     #[serde(with = "string_or_float")]
     pub qty: f64,
-
-    // Never serialized.
-    #[serde(skip_serializing)]
-    ignore: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -97,10 +93,6 @@ pub struct Asks {
     pub price: f64,
     #[serde(with = "string_or_float")]
     pub qty: f64,
-
-    // Never serialized.
-    #[serde(skip_serializing)]
-    ignore: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/model/websocket.rs
+++ b/src/model/websocket.rs
@@ -2,8 +2,8 @@ use super::{
     string_or_float, Asks, Bids, Kline, OrderBook, OrderExecType, OrderRejectReason, OrderStatus,
     OrderType, Side, TimeInForce,
 };
+use failure::_core::fmt::Formatter;
 use serde::{Deserialize, Serialize};
-use failure::_core::fmt::{Formatter};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Subscription {
@@ -23,16 +23,20 @@ pub enum Subscription {
 pub enum UpdateSpeed {
     Default,
     Slow,
-    Fast
+    Fast,
 }
 
 impl std::fmt::Display for UpdateSpeed {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", match self {
-            UpdateSpeed::Default=> "",
-            UpdateSpeed::Slow=> "@1000ms",
-            UpdateSpeed::Fast => "@100ms"
-        })
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Default => "",
+                Self::Slow => "@1000ms",
+                Self::Fast => "@100ms",
+            }
+        )
     }
 }
 

--- a/src/model/websocket.rs
+++ b/src/model/websocket.rs
@@ -3,6 +3,7 @@ use super::{
     OrderType, Side, TimeInForce,
 };
 use serde::{Deserialize, Serialize};
+use failure::_core::fmt::{Formatter};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Subscription {
@@ -14,8 +15,25 @@ pub enum Subscription {
     MiniTickerAll,
     Ticker(String), // symbol
     TickerAll,
-    OrderBook(String, i64), //symbol, depth
-    Depth(String),          //symbol
+    OrderBook(String, i64, UpdateSpeed), //symbol, depth
+    Depth(String, UpdateSpeed),          //symbol, update speed
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum UpdateSpeed {
+    Default,
+    Slow,
+    Fast
+}
+
+impl std::fmt::Display for UpdateSpeed {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", match self {
+            UpdateSpeed::Default=> "",
+            UpdateSpeed::Slow=> "@1000ms",
+            UpdateSpeed::Fast => "@100ms"
+        })
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/model/websocket.rs
+++ b/src/model/websocket.rs
@@ -15,7 +15,7 @@ pub enum Subscription {
     MiniTickerAll,
     Ticker(String), // symbol
     TickerAll,
-    OrderBook(String, i64, UpdateSpeed), //symbol, depth
+    OrderBook(String, i64, UpdateSpeed), //symbol, depth, update speed
     Depth(String, UpdateSpeed),          //symbol, update speed
 }
 

--- a/src/model/websocket.rs
+++ b/src/model/websocket.rs
@@ -28,7 +28,7 @@ pub enum UpdateSpeed {
 
 impl std::fmt::Display for UpdateSpeed {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", match self {
+        write!(f, "{}", match self {
             UpdateSpeed::Default=> "",
             UpdateSpeed::Slow=> "@1000ms",
             UpdateSpeed::Fast => "@100ms"


### PR DESCRIPTION
I tried to start a depth stream, but I was getting this error:
`Error: invalid length 2, expected struct Bids with 3 elements at line 1 column 112`
After removing field named "ignore" from model.Asks and model.Bids structs the error dissapears.
Additionally, I added the possibility to set update speed as in binance documentation to one of: 100ms, 1000ms. Please review :)